### PR TITLE
Updated code CSS wordbreak settings

### DIFF
--- a/lib/common.css
+++ b/lib/common.css
@@ -42,7 +42,7 @@ p {
 /* Allow wrapping code and remove colored background */
 code, tt {
   white-space: pre-wrap;
-  word-break: break-all;
+  word-break: break-word;
   word-wrap: break-word;
   border-width: 0px;
   background-color: inherit;


### PR DESCRIPTION
Updates &lt;code&gt; tag CSS to enable breaking on word boundaries rather than
on any character. This stops things like package names breaking mid-word rather
than on the closest appropriate period character, improving readability.

Before (note the `io.netty.example` part):

![image](https://user-images.githubusercontent.com/73482956/127737624-22541970-1a43-45b2-a764-b3903cd37b44.png)


After:

![image](https://user-images.githubusercontent.com/73482956/127737618-bf6f374c-c537-44c4-8ab1-9658efb82423.png)
