### PR TITLE
fix netty5 example links on wiki page

### DIFF
--- a/_ext/pipeline.rb
+++ b/_ext/pipeline.rb
@@ -74,10 +74,12 @@ class ReleaseInfo
   module Release
     def example_url(page, name = nil)
       if self.major_version > 3
+        package_name = if self.major_version == 5 then "netty5" else "netty" end
+        branch_name = if self.major_version == 5 then "main" else self.branch end
         if name.nil?
-          'https://github.com/netty/netty/tree/' + self.branch + '/example/src/main/java/io/netty/example'
+          'https://github.com/netty/netty/tree/' + branch_name + '/example/src/main/java/io/' + package_name + '/example'
         else
-          RelativeSiteUrl.get(self.site, page) + '/' + self.simple_version + '/xref/io/netty/example/' + name + '/package-summary.html'
+          RelativeSiteUrl.get(self.site, page) + '/' + self.simple_version + '/xref/io/' + package_name + '/example/' + name + '/package-summary.html'
         end
       else
         # The WorldClock example was LocalTime in 3.


### PR DESCRIPTION
I found two related issues on netty5 link generation examples, both fixes are on the same function (example_url)

first issue: on the examples section there is one github example link for each major version
fix: the netty5 version is on the main branch not in 5.0 branch

second issue: the links on the netty 5.0 examples tab were pointing to netty package instead of netty5 package
fix: use netty5 package for 5.0 version and netty for 4.x versions

I did manual tests for all these scenarios and everything looks good!