### PR TITLE
Mark Netty 3.10 and 4.0 as EOL on the downloads page

### DIFF
--- a/_config/site.yml
+++ b/_config/site.yml
@@ -7,15 +7,19 @@ releases:
   - version: 5.0.0.Alpha5
     date: 28-Sep-2022
     stable: false 
+    eol: false
   - version: 4.1.110.Final
     date: 22-May-2024
     stable: stable
+    eol: false
   - version: 4.0.56.Final
     date: 05-Feb-2018
-    stable: true
+    stable: false
+    eol: true
   - version: 3.10.6.Final
     date: 29-Jun-2016
-    stable: true
+    stable: false
+    eol: true
 
 twitter_search_url: 'https://twitter.com/search?q=%40netty_project OR %23netty lang%3Aen'
 

--- a/downloads.html.haml
+++ b/downloads.html.haml
@@ -19,11 +19,12 @@ title: Downloads
               &dash; #{r.date}
               - if r.recommended?
                 (Stable, Recommended)
+              - elsif r.stable
+                (Stable)
+              - elsif r.eol
+                (EOL)
               - else
-                - if r.stable
-                  (Stable)
-                - else
-                  (Development)
+                (Development)
 
       %p <a href="https://github.com/netty/netty/milestones?state=closed">Changelogs</a> and <a href="https://github.com/netty/netty/milestones?state=open">road map</a> are available in our issue tracker.
 


### PR DESCRIPTION
The last release was 8 years ago for the 3.10 line and 6 years ago for the 4.0 line. The downloads page previously showed them as stable, however new projects should use the 4.1 line instead. To indicate this, mark them as EOL.

| Before | After |
| ------ | ----- |
| ![image](https://github.com/netty/netty-website/assets/21343173/c8f064df-1381-42b9-96e8-ee600226f70c) | ![image](https://github.com/netty/netty-website/assets/21343173/e746948d-0ba5-4c88-9114-f83bb4a3e542) |