### PR TITLE
fix typo in 4.2.0 rc4 news

### DIFF
--- a/news/2025-03-07-4-2-0-RC4.md
+++ b/news/2025-03-07-4-2-0-RC4.md
@@ -4,9 +4,9 @@ title: 'Netty 4.2.0.RC4 released'
 author: normanmaurer
 ---
 
-We are happy to announce the release of the third release canidate for the upcoming netty version 4.2.0. Everyone using netty 4.1.x should be able to upgrade to 4.2.0.RC4 without any API breakage. The only new requirement is JDK8 or later. 
+We are happy to announce the release of the third release candidate for the upcoming netty version 4.2.0. Everyone using netty 4.1.x should be able to upgrade to 4.2.0.RC4 without any API breakage. The only new requirement is JDK8 or later. 
 
-We encourage users of netty 4.1.x to try out this alpha release and so provide feedback if any breakage is noticed. This will help us to be  aware of any problems early in the release cycle. That said, be aware that this is only an release canidate and so __shouldn't__ be considered for production usage yet.
+We encourage users of netty 4.1.x to try out this alpha release and so provide feedback if any breakage is noticed. This will help us to be  aware of any problems early in the release cycle. That said, be aware that this is only an release candidate and so __shouldn't__ be considered for production usage yet.
 
 Netty 4.2.0 will come with some exciting new features that you can learn more about in the announcement of [netty 4.2.0.Alpha1](https://netty.io/news/2024/06/12/4-2-0-Alpha1.html).
 


### PR DESCRIPTION
"canidate" -> "candidate"

# Reference

https://en.wikipedia.org/wiki/Software_release_life_cycle

